### PR TITLE
Add async fetch bridge and async sync flow

### DIFF
--- a/Magisterium/Networking/Sources/SpellRemoteSource.swift
+++ b/Magisterium/Networking/Sources/SpellRemoteSource.swift
@@ -22,4 +22,5 @@ struct SpellRemoteSource {
     }
 }
 
-extension SpellRemoteSource: SpellRemoteFetching {}
+extension SpellRemoteSource: SpellRemoteFetching {
+}

--- a/Magisterium/Persistence/Repository/Spell/SpellRemoteFetching.swift
+++ b/Magisterium/Persistence/Repository/Spell/SpellRemoteFetching.swift
@@ -8,5 +8,25 @@
 import Combine
 
 protocol SpellRemoteFetching {
-    func fetchAll() -> AnyPublisher<[SpellDto], NetworkError>
+	func fetchAll() -> AnyPublisher<[SpellDto], NetworkError>
+	func fetchAllAsync() async throws -> [SpellDto]
+}
+
+extension SpellRemoteFetching {
+	func fetchAllAsync() async throws -> [SpellDto] {
+		try await withCheckedThrowingContinuation { continuation in
+			var cancellable: AnyCancellable?
+			cancellable = fetchAll().sink(
+				receiveCompletion: { completion in
+					if case .failure(let error) = completion {
+						continuation.resume(throwing: error)
+					}
+				},
+				receiveValue: { value in
+					continuation.resume(returning: value)
+					_ = cancellable
+				}
+			)
+		}
+	}
 }

--- a/MagisteriumTests/Persistence/Repository/Spell/SpellMapperUpdateTests.swift
+++ b/MagisteriumTests/Persistence/Repository/Spell/SpellMapperUpdateTests.swift
@@ -14,7 +14,7 @@ struct SpellMapperUpdateTests {
 
     @Test("Updates all mutable fields")
     func updatesAllFields() {
-        var spell = Spell(
+		let spell = Spell(
             id: "accio",
             name: "Accio",
             incantation: nil,


### PR DESCRIPTION
Introduce async/await support for remote fetching and migrate SpellSyncService to an async flow. Added fetchAllAsync() to SpellRemoteFetching with a Combine->async bridge (withCheckedThrowingContinuation). SpellSyncService now accepts a remote dependency explicitly, provides a convenience init for the default SpellRemoteSource, and replaces the previous Combine sink with Task { await fetchAndUpsertAll(context:) }. A @MainActor extension implements fetchAndUpsertAll(context:) and a helper fetchAllDTOsAsync() that bridges the publisher to async code. Tests updated to async: fixed a minor immutable binding in SpellMapperUpdateTests and replaced previous bootstrap test usage with async calls; added new async tests for fetchAndUpsertAll insert/upsert behavior. Overall: moving from Combine subscriptions in the service to structured concurrency and simplifying async handling.